### PR TITLE
Fixed malformed RSS link

### DIFF
--- a/src/Nancy.Blog/Views/Layout.cshtml
+++ b/src/Nancy.Blog/Views/Layout.cshtml
@@ -24,7 +24,7 @@
     <link href="/content/css/style.css" media="screen" rel="stylesheet">
     <link href="/content/css/screen.css" media="screen" rel="stylesheet">
     
-    <link rel="alternate" type="application/rss+xml" title="Nancy Blog" href="http:/blog.nancyfx.org/rss" />
+    <link rel="alternate" type="application/rss+xml" title="Nancy Blog" href="http://blog.nancyfx.org/rss" />
 </head>
 <body>
     <div itemscope itemtype="http://schema.org/Article" class="body_wrap">


### PR DESCRIPTION
Changed `http:/blog.nancyfx.org/rss` to `http://blog.nancyfx.org/rss`
