### PR TITLE
Change 'feedurl' and 'authoremail' for Jim Liddell

### DIFF
--- a/src/Nancy.Blog/feeddata.json
+++ b/src/Nancy.Blog/feeddata.json
@@ -50,9 +50,9 @@
     },
     {
         "id": "jimliddell",
-        "feedurl": "http://liddellj.com/rss",
+        "feedurl": "http://liddellj.com/feed.xml",
         "author": "Jim Liddell",
-        "authoremail": "jim@liddellj.com",
+        "authoremail": "jim@liddell.me",
         "gravatarurl": "https://s.gravatar.com/avatar/98f93d43537cdf3fb5e8b13876633111?s=128"
     },
     {


### PR DESCRIPTION
I've moved my blog to Jekyll - so the URL of the RSS feed changed. I've also changed email address.